### PR TITLE
WIP: Zarr plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .coverage*
 .idea/
 __pycache__/
+.cache/
+*egg-info/

--- a/intake_xarray/__init__.py
+++ b/intake_xarray/__init__.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-# -----------------------------------------------------------------------------
-# Copyright 2016 Continuum Analytics, Inc.
-#
-# May be copied and distributed freely only as part of an Anaconda or
-# Miniconda installation.
-# -----------------------------------------------------------------------------
 from intake.source import base
 import xarray as xr
 from ._version import get_versions
@@ -74,8 +67,10 @@ class ZarrPlugin(base.Plugin):
 
 
 class DataSourceMixin:
+    """Common behaviours for plugins in this repo"""
 
     def _get_schema(self):
+        """Make schema object, which embeds xarray object and some details"""
         if self._ds is None:
             self._open_dataset()
 
@@ -93,19 +88,27 @@ class DataSourceMixin:
             extra_metadata=metadata)
 
     def read(self):
+        """Return a version of the xarray with all the data in memory"""
         self._load_metadata()
         return self._ds.load()
 
     def read_chunked(self):
+        """Return xarray object (which will have chunks)"""
         self._load_metadata()
         return self._ds
 
     def read_partition(self, i):
+        """Fetch one chunk of data at tuple index i
+
+        (not yet implemented)
+        """
         raise NotImplementedError
 
     def to_dask(self):
+        """Return xarray object where variables are dask arrays"""
         return self.read_chunked()
 
     def close(self):
+        """Delete open file from memory"""
         self._ds.close()
         self._ds = None

--- a/intake_xarray/__init__.py
+++ b/intake_xarray/__init__.py
@@ -12,7 +12,7 @@ del get_versions
 
 
 class NetCDFPlugin(base.Plugin):
-    """Plugin for xarray reader"""
+    """Plugin for netcdf->xarray reader"""
 
     def __init__(self):
         super(NetCDFPlugin, self).__init__(
@@ -41,3 +41,32 @@ class NetCDFPlugin(base.Plugin):
             chunks=chunks,
             xarray_kwargs=source_kwargs,
             metadata=base_kwargs['metadata'])
+
+
+class ZarrPlugin(base.Plugin):
+    """zarr>xarray reader"""
+
+    def __init__(self):
+        super(ZarrPlugin, self).__init__(
+            name='zarr',
+            version=__version__,
+            container='xarray',
+            partition_access=True
+        )
+
+    def open(self, urlpath, storage_options=None, **kwargs):
+        """
+        Parameters
+        ----------
+        urlpath: str
+            Path to source. This can be a local directory or a remote data
+            service (i.e., with a protocol specifier like ``'s3://``).
+        storage_options: dict
+            Parameters passed to the backend file-system
+        kwargs:
+            Further parameters are passed to xr.open_zarr
+        """
+        from intake_xarray.xzarr import ZarrSource
+        base_kwargs, source_kwargs = self.separate_base_kwargs(kwargs)
+        return ZarrSource(urlpath, storage_options, base_kwargs['metadata'],
+                          **source_kwargs)

--- a/intake_xarray/netcdf.py
+++ b/intake_xarray/netcdf.py
@@ -65,3 +65,4 @@ class NetCDFSource(base.DataSource):
 
     def close(self):
         self._ds.close()
+        self._ds = None

--- a/intake_xarray/netcdf.py
+++ b/intake_xarray/netcdf.py
@@ -3,6 +3,7 @@ import xarray as xr
 from intake.source import base
 from . import DataSourceMixin
 
+
 class NetCDFSource(DataSourceMixin, base.DataSource):
     """Open a xarray file.
 

--- a/intake_xarray/netcdf.py
+++ b/intake_xarray/netcdf.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import xarray as xr
 from intake.source import base
+from . import DataSourceMixin
 
-
-class NetCDFSource(base.DataSource):
+class NetCDFSource(DataSourceMixin, base.DataSource):
     """Open a xarray file.
 
     Parameters
@@ -27,42 +27,6 @@ class NetCDFSource(base.DataSource):
 
     def _open_dataset(self):
         url = self.urlpath
-        if "*" in url:
-            return xr.open_mfdataset(url, chunks=self.chunks, **self._kwargs)
-        else:
-            return xr.open_dataset(url, chunks=self.chunks, **self._kwargs)
+        _open_dataset = xr.open_mfdataset if "*" in url else xr.open_dataset
 
-    def _get_schema(self):
-        if self._ds is None:
-            self._ds = self._open_dataset()
-
-        metadata = {
-            'dims': dict(self._ds.dims),
-            'data_vars': tuple(self._ds.data_vars.keys()),
-            'coords': tuple(self._ds.coords.keys())
-        }
-        metadata.update(self._ds.attrs)
-        return base.Schema(
-            datashape=None,
-            dtype=xr.Dataset,
-            shape=None,
-            npartitions=None,
-            extra_metadata=metadata)
-
-    def read(self):
-        self._load_metadata()
-        return self._ds.load()
-
-    def read_chunked(self):
-        self._load_metadata()
-        return self._ds
-
-    def read_partition(self, i):
-        raise NotImplementedError
-
-    def to_dask(self):
-        return self.read_chunked()
-
-    def close(self):
-        self._ds.close()
-        self._ds = None
+        self._ds = _open_dataset(url, chunks=self.chunks, **self._kwargs)

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -31,8 +31,11 @@ class ZarrSource(DataSourceMixin, base.DataSource):
         update_storage_options(options, self.storage_options)
 
         self._fs, _ = get_fs(protocol, options)
-        self._mapper = get_mapper(protocol, self._fs, urlpath)
-        self._ds = xr.open_zarr(self._mapper, **self.kwargs)
+        if protocol != 'file':
+            self._mapper = get_mapper(protocol, self._fs, urlpath)
+            self._ds = xr.open_zarr(self._mapper, **self.kwargs)
+        else:
+            self._ds = xr.open_zarr(self.urlpath, **self.kwargs)
 
     def close(self):
         super(ZarrSource, self).close()

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -4,7 +4,7 @@ from dask.bytes.core import get_fs, infer_options, update_storage_options
 
 
 class ZarrSource(base.DataSource):
-    """Open a xarray file.
+    """Open a xarray dataset.
 
     Parameters
     ----------

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -1,0 +1,82 @@
+import xarray as xr
+from intake.source import base
+from dask.bytes.core import get_fs, infer_options, update_storage_options
+
+
+class ZarrSource(base.DataSource):
+    """Open a xarray file.
+
+    Parameters
+    ----------
+    urlpath: str
+        Path to source. This can be a local directory or a remote data
+        service (i.e., with a protocol specifier like ``'s3://``).
+    storage_options: dict
+        Parameters passed to the backend file-system
+    kwargs:
+        Further parameters are passed to xr.open_zarr
+    """
+
+    def __init__(self, urlpath, storage_options=None, metadata=None, **kwargs):
+        super(ZarrSource, self).__init__(
+              container='xarray', metadata=metadata)
+        self.urlpath = urlpath
+        self.storage_options = storage_options
+        self.kwargs = kwargs
+        self._ds = None
+
+    def _open_dataset(self):
+        urlpath, protocol, options = infer_options(self.urlpath)
+        update_storage_options(options, self.storage_options)
+
+        self._fs, _ = get_fs(protocol, options)
+        self._mapper = get_mapper(protocol, self._fs, urlpath)
+        self._ds = xr.open_zarr(self._mapper, **self.kwargs)
+
+    def _get_schema(self):
+        if self._ds is None:
+            self._open_dataset()
+
+        metadata = {
+            'dims': dict(self._ds.dims),
+            'data_vars': tuple(self._ds.data_vars.keys()),
+            'coords': tuple(self._ds.coords.keys())
+        }
+        metadata.update(self._ds.attrs)
+        return base.Schema(
+            datashape=None,
+            dtype=xr.Dataset,
+            shape=None,
+            npartitions=None,
+            extra_metadata=metadata)
+
+    def read(self):
+        self._load_metadata()
+        return self._ds.load()
+
+    def read_chunked(self):
+        self._load_metadata()
+        return self._ds
+
+    def read_partition(self, i):
+        raise NotImplementedError
+
+    def to_dask(self):
+        return self.read_chunked()
+
+    def close(self):
+        self._ds.close()
+        self._ds = None
+        self._fs = None
+        self._mapper = None
+
+
+def get_mapper(protocol, fs, path):
+    if protocol == 's3':
+        from s3fs.mapping import S3Map
+        return S3Map(path, fs)
+    elif protocol == 'gcs':
+        from gcsfs.mapping import GCSMap
+        return GCSMap(path, fs)
+    else:
+        raise NotImplementedError

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,9 +2,12 @@
 
 import os
 import pytest
+import shutil
+import tempfile
 import xarray as xr
 
 from intake_xarray.netcdf import NetCDFSource
+from intake_xarray.xzarr import ZarrSource
 
 TEST_DATA_DIR = 'tests/data'
 TEST_DATA = 'example_1.nc'
@@ -12,10 +15,22 @@ TEST_URLPATH = os.path.join(TEST_DATA_DIR, TEST_DATA)
 
 
 @pytest.fixture
-def source():
+def cdf_source():
     return NetCDFSource(TEST_URLPATH, {})
 
 
 @pytest.fixture
 def dataset():
     return xr.open_dataset(TEST_URLPATH)
+
+
+@pytest.fixture(scope='module')
+def zarr_source():
+    pytest.importorskip('zarr')
+    try:
+        tdir = tempfile.mkdtemp()
+        data = xr.open_dataset(TEST_URLPATH)
+        data.to_zarr(tdir)
+        yield ZarrSource(tdir)
+    finally:
+        shutil.rmtree(tdir)


### PR DESCRIPTION
Example
```
In [1]: %cat cat.yaml
sources:
  newman:
    description: Newmann Ensemble
    driver: zarr
    args:
      urlpath: "gcs://pangeo-data/newman-met-ensemble/"

In [2]: import intake

In [3]: cat = intake.Catalog('cat.yaml')

In [4]: cat.newman.read_chunked()
Out[4]:
<xarray.Dataset>
Dimensions:    (ensemble: 9, lat: 224, lon: 464, time: 12054)
Coordinates:
  * lat        (lat) float64 25.06 25.19 25.31 25.44 25.56 25.69 25.81 25.94 ...
  * lon        (lon) float64 -124.9 -124.8 -124.7 -124.6 -124.4 -124.3 ...
  * time       (time) datetime64[ns] 1980-01-01 1980-01-02 1980-01-03 ...
Dimensions without coordinates: ensemble
Data variables:
    elevation  (ensemble, lat, lon) float64 dask.array<shape=(9, 224, 464), chunksize=(1, 224, 464)>
    mask       (ensemble, lat, lon) int32 dask.array<shape=(9, 224, 464), chunksize=(1, 224, 464)>
    pcp        (ensemble, time, lat, lon) float64 dask.array<shape=(9, 12054, 224, 464), chunksize=(1, 287, 224, 464)>
    t_max      (ensemble, time, lat, lon) float64 dask.array<shape=(9, 12054, 224, 464), chunksize=(1, 287, 224, 464)>
    t_mean     (ensemble, time, lat, lon) float64 dask.array<shape=(9, 12054, 224, 464), chunksize=(1, 287, 224, 464)>
    t_min      (ensemble, time, lat, lon) float64 dask.array<shape=(9, 12054, 224, 464), chunksize=(1, 287, 224, 464)>
    t_range    (ensemble, time, lat, lon) float64 dask.array<shape=(9, 12054, 224, 464), chunksize=(1, 287, 224, 464)>
Attributes:
    _ARRAY_DIMENSIONS:         {'ensemble': 9, 'lat': 224, 'lon': 464, 'time'...
    history:                   Version 1.0 of ensemble dataset, created Decem...
    institution:               National Center for Atmospheric Research (NCAR...
    nco_openmp_thread_number:  1
    references:                Newman et al. 2015: Gridded Ensemble Precipita...
    source:                    Generated using version 1.0 of CONUS ensemble ...
    title:                     CONUS daily 12-km gridded ensemble precipitati...
```