### PR TITLE
Implement get_partition

### DIFF
--- a/tests/data/catalog.yaml
+++ b/tests/data/catalog.yaml
@@ -22,4 +22,5 @@ sources:
     driver: rasterio
     args:
       urlpath: '{{ CATALOG_DIR }}/RGB.byte.tif'
-      chunks: {}
+      chunks:
+        band: 1


### PR DESCRIPTION
Coming soon: reading by partition from remote Intake server.

Note that the approach taken here could be used for all arrays too, but we have no plugins yet for straight arrays.

