### PR TITLE
Adding a pattern mixin and allow path_as_pattern to be a string

### DIFF
--- a/intake_xarray/base.py
+++ b/intake_xarray/base.py
@@ -1,5 +1,5 @@
 from . import __version__
-from intake.source.base import DataSource, Schema
+from intake.source.base import DataSource, Schema, PatternMixin
 from .xarray_container import ZarrSerialiser
 
 

--- a/tests/data/catalog.yaml
+++ b/tests/data/catalog.yaml
@@ -24,7 +24,6 @@ sources:
       urlpath: '{{ CATALOG_DIR }}/RGB.byte.tif'
       chunks:
         band: 1
-      concat_dim: concat_dim
   tiff_glob_source:
     description: "https://github.com/mapbox/rasterio/blob/master/tests/data/RGB.byte.tif"
     driver: rasterio
@@ -32,7 +31,6 @@ sources:
       urlpath: '{{ CATALOG_DIR }}/*.byte.tif'
       chunks:
         band: 1
-      concat_dim: concat_dim
   empty_glob:
     description: Empty
     driver: rasterio
@@ -40,7 +38,6 @@ sources:
       urlpath: '{{ CATALOG_DIR }}/*.empty'
       chunks:
         band: 1
-      concat_dim: concat_dim
   cached_tiff_glob_source:
     description: "https://github.com/mapbox/rasterio/blob/master/tests/data/RGB.byte.tif"
     driver: rasterio
@@ -52,7 +49,6 @@ sources:
       urlpath: '{{ CATALOG_DIR }}/*.byte.tif'
       chunks:
         band: 1
-      concat_dim: concat_dim
   pattern_tiff_source_concat_on_band:
     description: "https://github.com/mapbox/rasterio/blob/master/tests/data/<red|green>.tif"
     driver: rasterio
@@ -86,3 +82,12 @@ sources:
         band: 3
       concat_dim: band
       path_as_pattern: False
+  pattern_tiff_source_path_pattern_as_str:
+    description: "https://github.com/mapbox/rasterio/blob/master/tests/data/<red|green>.tif"
+    driver: rasterio
+    args:
+      urlpath: ['{{ CATALOG_DIR }}/little_red.tif', '{{ CATALOG_DIR }}/little_green.tif']
+      chunks:
+        band: 3
+      concat_dim: color
+      path_as_pattern: '{{ CATALOG_DIR }}/little_{color}.tif'

--- a/tests/test_intake_xarray.py
+++ b/tests/test_intake_xarray.py
@@ -200,3 +200,21 @@ def test_read_pattern_path_not_as_pattern():
 
     da = green.read()
     assert len(da.band) == 3
+
+
+def test_read_pattern_path_as_pattern_as_str_with_list_of_urlpaths():
+    pytest.importorskip('rasterio')
+    cat = intake.open_catalog(os.path.join(here, 'data', 'catalog.yaml'))
+    colors = cat.pattern_tiff_source_path_pattern_as_str()
+
+    da = colors.read()
+    assert da.shape == (2, 3, 64, 64)
+    assert len(da.color) == 2
+    assert set(da.color.data) == set(['red', 'green'])
+
+    assert da.sel(color='red').shape == (3, 64, 64)
+
+    rgb = {'red': [204, 17, 17], 'green': [17, 204, 17]}
+    for color, values in rgb.items():
+        for i, v in enumerate(values):
+            assert (da.sel(color=color).sel(band=i+1).values == v).all()


### PR DESCRIPTION
I wanted to add the functionality of https://github.com/ContinuumIO/intake/pull/164 and ended up making a mixin. I think it is fairly clean.