### PR TITLE
Add support for read() on RemoteXarray.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,6 @@ script:
   if [ -n "$TRAVIS_TAG" ]; then
       # If tagged git version, upload package to main channel
       anaconda -t ${ANACONDA_TOKEN} upload -u intake --force `conda build --output ./conda`
-  else
-      # Otherwise upload package to dev channel
-      anaconda -t ${ANACONDA_TOKEN} upload -u intake --label dev --force `conda build --output ./conda`
   fi
 notifications:
   email: false

--- a/intake_xarray/xarray_container.py
+++ b/intake_xarray/xarray_container.py
@@ -163,6 +163,10 @@ class RemoteXarray(RemoteSource):
         self._get_schema()
         return self._ds
 
+    def read(self):
+        self._get_schema()
+        return self._ds.load()
+
     def close(self):
         self._ds = None
         self._schema = None

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -43,6 +43,8 @@ def test_remote_netcdf(intake_server):
     assert source._schema is not None
     assert (source.to_dask().rh.data.compute() ==
             cat_local.xarray_source.to_dask().rh.data.compute()).all()
+    assert (source.read() ==
+            cat_local.xarray_source.read()).all()
 
 
 def test_remote_tiff(intake_server):
@@ -58,3 +60,5 @@ def test_remote_tiff(intake_server):
     remote = source.to_dask().data.compute()
     local = cat_local.tiff_source.to_dask().data.compute()
     assert (remote == local).all()
+    assert (source.read() ==
+            cat_local.xarray_source.read()).all()


### PR DESCRIPTION
Currently, calling`remote_source.read()` on a `RemoteXarray` causes the following error on the server.

```
Traceback (most recent call last):
  File "/Users/dallan/venv/bnl/lib/python3.7/site-packages/tornado/web.py", line 1512, in _execute
    result = yield result
  File "/Users/dallan/venv/bnl/lib/python3.7/site-packages/tornado/gen.py", line 1055, in run
    value = future.result()
  File "/Users/dallan/venv/bnl/lib/python3.7/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "/Users/dallan/venv/bnl/lib/python3.7/site-packages/tornado/gen.py", line 292, in wrapper
    result = func(*args, **kwargs)
  File "/usr/local/Cellar/python/3.7.1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/types.py", line 277, in wrapped
    coro = func(*args, **kwargs)
  File "/Users/dallan/Repos/bnl/intake/intake/cli/server/server.py", line 313, in post
    chunk = source.read_partition(partition)
  File "/Users/dallan/Repos/bnl/intake-xarray/intake_xarray/base.py", line 54, in read_partition
    raise TypeError('For Xarray sources, must specify partition as '
TypeError: For Xarray sources, must specify partition as tuple
```

This PR solves the immediate issue simply enough.

Separately, it might also be worth considering whether `read_partition` should be named `read_xarray_partition` since it has a special signature that is not compatible with the `read_partition` expected by the server.